### PR TITLE
Make everything fully compatible with the node-sha3 API

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,22 +5,22 @@ const hashLengths = [ 224, 256, 384, 512 ]
 var hash = function (bitcount) {
   if (bitcount !== undefined && hashLengths.indexOf(bitcount) == -1)
     throw new Error('Unsupported hash length')
-  this.content = ''
+  this.content = []
   this.bitcount = bitcount ? 'keccak_' + bitcount : 'keccak_512'
 }
 
 hash.prototype.update = function (i) {
   if (Buffer.isBuffer(i))
-    this.content = i
+    this.content.push(i)
   else if (typeof i === 'string')
-    this.content = new Buffer(i)
+    this.content.push(new Buffer(i))
   else
     throw new Error('Unsupported argument to update')
   return this
 }
 
 hash.prototype.digest = function (encoding) {
-  var result = Sha3[this.bitcount](this.content)
+  var result = Sha3[this.bitcount](Buffer.concat(this.content))
   if (encoding === 'hex')
     return result
   else if (encoding === 'binary' || encoding === undefined)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var hash = function (bitcount) {
 
 hash.prototype.update = function (i) {
   this.content = Buffer.isBuffer(i) ? i : new Buffer(i);
+  return this
 }
 
 hash.prototype.digest = function (encoding) {

--- a/index.js
+++ b/index.js
@@ -20,11 +20,13 @@ hash.prototype.update = function (i) {
 }
 
 hash.prototype.digest = function (encoding) {
-  var result = Sha3[this.bitcount](this.content) 
-  if(encoding === 'hex')
+  var result = Sha3[this.bitcount](this.content)
+  if (encoding === 'hex')
     return result
-  else
+  else if (encoding === 'binary' || encoding === undefined)
     return new Buffer(result, 'hex').toString('binary')
+  else
+    throw new Error('Unsupported encoding for digest: ' + encoding)
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 const Sha3 = require('js-sha3')
 
+const hashLengths = [ 224, 256, 384, 512 ]
+
 var hash = function (bitcount) {
+  if (bitcount !== undefined && hashLengths.indexOf(bitcount) == -1)
+    throw new Error('Unsupported hash length')
   this.content = ''
   this.bitcount = bitcount ? 'keccak_' + bitcount : 'keccak_512'
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,12 @@ var hash = function (bitcount) {
 }
 
 hash.prototype.update = function (i) {
-  this.content = Buffer.isBuffer(i) ? i : new Buffer(i);
+  if (Buffer.isBuffer(i))
+    this.content = i
+  else if (typeof i === 'string')
+    this.content = new Buffer(i)
+  else
+    throw new Error('Unsupported argument to update')
   return this
 }
 


### PR DESCRIPTION
This passes the tests in node-sha3/tests/unit_test.js (except in the last test, add the ```new``` keyword for the constructor)